### PR TITLE
Refactoring enum validator by using type switch

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -4,147 +4,114 @@ import (
 	"fmt"
 )
 
-type IntEnumValidator struct {
-	definition IntEnumValidatorDefinition
+type EnumValidator struct {
+	definition EnumValidatorDefinition
 }
 
-type IntEnumValidatorDefinition struct {
-	Enumerate []int `json:"enum"`
+type EnumValidatorDefinition struct {
+	Enumerate interface{} `json:"enum"`
 }
 
-type IntEnumValidationError struct {
-	Definition IntEnumValidatorDefinition `json:"definition"`
-	Input      int                        `json:"input"`
+type EnumValidationError struct {
+	Definition EnumValidatorDefinition `json:"definition"`
+	Input      interface{}             `json:"input"`
 }
 
-func (i IntEnumValidationError) Error() string {
+func (i EnumValidationError) Error() string {
 	return fmt.Sprintf("input value '%d' does not listed in enumerate '%v'\n", i.Input, i.Definition.Enumerate)
 }
 
-func NewIntEnumValidator(definition IntEnumValidatorDefinition) (IntEnumValidator, error) {
+func NewEnumValidator(definition EnumValidatorDefinition) (EnumValidator, error) {
 	enumerate := definition.Enumerate
-	len := len(enumerate)
-	if len == 0 {
-		return IntEnumValidator{}, EmptyError{"the enumerate should have at least one element"}
-	}
+	switch enum := enumerate.(type) {
+	case []int:
+		len := len(enum)
+		if len == 0 {
+			return EnumValidator{}, EmptyError{"the enumerate should have at least one element"}
+		}
 
-	for i := 0; i < len-1; i++ {
-		e := enumerate[i]
-		for j := i + 1; j < len; j++ {
-			if enumerate[j] == e {
-				return IntEnumValidator{}, DuplicationError{"the elements of enumerate should not be duplicated"}
+		for i := 0; i < len-1; i++ {
+			e := enum[i]
+			for j := i + 1; j < len; j++ {
+				if enum[j] == e {
+					return EnumValidator{}, DuplicationError{"the elements of enumerate should not be duplicated"}
+				}
 			}
 		}
+	case []float64:
+		len := len(enum)
+		if len == 0 {
+			return EnumValidator{}, EmptyError{"the enumerate should have at least one element"}
+		}
+
+		for i := 0; i < len-1; i++ {
+			e := enum[i]
+			for j := i + 1; j < len; j++ {
+				if enum[j] == e {
+					return EnumValidator{}, DuplicationError{"the elements of enumerate should not be duplicated"}
+				}
+			}
+		}
+	case []string:
+		len := len(enum)
+		if len == 0 {
+			return EnumValidator{}, EmptyError{"the enumerate should have at least one element"}
+		}
+
+		for i := 0; i < len-1; i++ {
+			e := enum[i]
+			for j := i + 1; j < len; j++ {
+				if enum[j] == e {
+					return EnumValidator{}, DuplicationError{"the elements of enumerate should not be duplicated"}
+				}
+			}
+		}
+	default:
+		return EnumValidator{}, TypeError{"the enumerate should be []int, []float64 or []string"}
 	}
 
-	return IntEnumValidator{definition}, nil
+	return EnumValidator{definition}, nil
 
 }
 
-func (i IntEnumValidator) Validate(input int) error {
-	for _, e := range i.definition.Enumerate {
-		if input == e {
-			return nil
+func (i EnumValidator) Validate(input interface{}) error {
+	switch input := input.(type) {
+	case int:
+		enum, ok := i.definition.Enumerate.([]int)
+		if !ok {
+			return TypeError{"input and element of enumerate should be same type"}
 		}
+		for _, e := range enum {
+			if input == e {
+				return nil
+			}
+		}
+	case float64:
+		enum, ok := i.definition.Enumerate.([]float64)
+		if !ok {
+			return TypeError{"input and element of enumerate should be same type"}
+		}
+		for _, e := range enum {
+			if input == e {
+				return nil
+			}
+		}
+	case string:
+		enum, ok := i.definition.Enumerate.([]string)
+		if !ok {
+			return TypeError{"input and element of enumerate should be same type"}
+		}
+		for _, e := range enum {
+			if input == e {
+				return nil
+			}
+		}
+	default:
+		return TypeError{"input should be same type as element of enumerate"}
 	}
-	return &IntEnumValidationError{
+
+	return &EnumValidationError{
 		i.definition,
-		input,
-	}
-}
-
-type StringEnumValidator struct {
-	definition StringEnumValidatorDefinition
-}
-
-type StringEnumValidatorDefinition struct {
-	Enumerate []string `json:"enum"`
-}
-
-type StringEnumValidationError struct {
-	Definition StringEnumValidatorDefinition `json:"definition"`
-	Input      string                        `json:"input"`
-}
-
-func (s StringEnumValidationError) Error() string {
-	return fmt.Sprintf("input value '%s' does not listed in enumerate '%v' \n", s.Input, s.Definition.Enumerate)
-}
-
-func NewStringEnumValidator(definition StringEnumValidatorDefinition) (StringEnumValidator, error) {
-	enumerate := definition.Enumerate
-	len := len(enumerate)
-	if len == 0 {
-		return StringEnumValidator{}, EmptyError{"the enumerate should have at least one element"}
-	}
-
-	for i := 0; i < len-1; i++ {
-		e := enumerate[i]
-		for j := i + 1; j < len; j++ {
-			if enumerate[j] == e {
-				return StringEnumValidator{}, DuplicationError{"the elements of enumerate should not be duplicated"}
-			}
-		}
-	}
-
-	return StringEnumValidator{definition}, nil
-}
-
-func (s StringEnumValidator) Validate(input string) error {
-	for _, e := range s.definition.Enumerate {
-		if input == e {
-			return nil
-		}
-	}
-	return &StringEnumValidationError{
-		s.definition,
-		input,
-	}
-}
-
-type FloatEnumValidator struct {
-	definition FloatEnumValidatorDefinition
-}
-
-type FloatEnumValidatorDefinition struct {
-	Enumerate []float64 `json:"enum"`
-}
-
-type FloatEnumValidationError struct {
-	Definition FloatEnumValidatorDefinition `json:"definition"`
-	Input      float64                      `json:"input"`
-}
-
-func (s FloatEnumValidationError) Error() string {
-	return fmt.Sprintf("input value '%g' does not listed in enumerate '%v'\n", s.Input, s.Definition.Enumerate)
-}
-
-func NewFloatEnumValidator(definition FloatEnumValidatorDefinition) (FloatEnumValidator, error) {
-	enumerate := definition.Enumerate
-	len := len(enumerate)
-	if len == 0 {
-		return FloatEnumValidator{}, EmptyError{"the enumerate should have at least one element"}
-	}
-
-	for i := 0; i < len-1; i++ {
-		e := enumerate[i]
-		for j := i + 1; j < len; j++ {
-			if enumerate[j] == e {
-				return FloatEnumValidator{}, DuplicationError{"the elements of enumerate should not be duplicated"}
-			}
-		}
-	}
-	return FloatEnumValidator{definition}, nil
-
-}
-
-func (f FloatEnumValidator) Validate(input float64) error {
-	for _, e := range f.definition.Enumerate {
-		if input == e {
-			return nil
-		}
-	}
-	return &FloatEnumValidationError{
-		f.definition,
 		input,
 	}
 }

--- a/enum_test.go
+++ b/enum_test.go
@@ -5,172 +5,190 @@ import (
 	"testing"
 )
 
-type IntEnumTestCase struct {
-	Definition IntEnumValidatorDefinition
+type EnumTestCase struct {
+	Definition EnumValidatorDefinition
 	Expected   error
 }
 
-func TestIntEnum(t *testing.T) {
-	tests := []IntEnumTestCase{{
-		Definition: IntEnumValidatorDefinition{Enumerate: []int{}},
-		Expected:   EmptyError{},
-	}, {
-		Definition: IntEnumValidatorDefinition{Enumerate: []int{0, 1, 0}},
-		Expected:   DuplicationError{},
-	}}
+func TestEnum(t *testing.T) {
+	tests := []EnumTestCase{
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []int{}},
+			Expected:   EmptyError{},
+		},
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []int{0, 1, 0}},
+			Expected:   DuplicationError{},
+		},
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []float64{}},
+			Expected:   EmptyError{},
+		},
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []float64{0.9, 1.0, 1.0}},
+			Expected:   DuplicationError{},
+		},
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []string{}},
+			Expected:   EmptyError{},
+		},
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []string{"foo", "bar", "foo"}},
+			Expected:   DuplicationError{},
+		},
+		{
+			Definition: EnumValidatorDefinition{Enumerate: []bool{true, false}},
+			Expected:   TypeError{},
+		},
+	}
 	for _, test := range tests {
-		_, err := NewIntEnumValidator(test.Definition)
+		_, err := NewEnumValidator(test.Definition)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.Expected) {
 			t.Errorf("expected:%v, actual:%v", reflect.TypeOf(test.Expected), reflect.TypeOf(err))
 		}
 	}
 }
 
-type IntEnumValidatorTestCase struct {
-	Input    int
+type EnumValidatorTestCase struct {
+	Input    interface{}
 	Expected error
 }
 
-func TestIntEnumvalidator(t *testing.T) {
-	definition := IntEnumValidatorDefinition{
+func TestEnumvalidator(t *testing.T) {
+	definition := EnumValidatorDefinition{
 		Enumerate: []int{401, 402, 403},
 	}
-	validator, err := NewIntEnumValidator(definition)
+	validator, err := NewEnumValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tests := []IntEnumValidatorTestCase{{
-		Input:    401,
-		Expected: nil,
-	}, {
-		Input:    402,
-		Expected: nil,
-	}, {
-		Input:    403,
-		Expected: nil,
-	}, {
-		Input: 501,
-		Expected: &IntEnumValidationError{
-			Input:      501,
-			Definition: definition,
+	tests := []EnumValidatorTestCase{
+		{
+			Input:    401,
+			Expected: nil,
 		},
-	}}
+		{
+			Input:    402,
+			Expected: nil,
+		},
+		{
+			Input:    403,
+			Expected: nil,
+		},
+		{
+			Input: 501,
+			Expected: &EnumValidationError{
+				Input:      501,
+				Definition: definition,
+			},
+		},
+		{
+			Input: 10.1,
+			Expected: TypeError{
+				message: "input and element of enumerate should be same type",
+			},
+		},
+		{
+			Input: true,
+			Expected: TypeError{
+				message: "input should be same type as element of enumerate",
+			},
+		},
+	}
 	for _, test := range tests {
 		err := validator.Validate(test.Input)
 		if !reflect.DeepEqual(err, test.Expected) {
-			t.Errorf("expected:%v ,actual:%v", test.Expected, err)
+			t.Errorf("\nexpected: %v \n  actual: %v", test.Expected, err)
 		}
 	}
-}
 
-type FloatEnumTestCase struct {
-	Definition FloatEnumValidatorDefinition
-	Expected   error
-}
-
-func TestFloatEnum(t *testing.T) {
-	tests := []FloatEnumTestCase{{
-		Definition: FloatEnumValidatorDefinition{Enumerate: []float64{}},
-		Expected:   EmptyError{},
-	}, {
-		Definition: FloatEnumValidatorDefinition{Enumerate: []float64{0.9, 1.0, 1.0}},
-		Expected:   DuplicationError{},
-	}}
-	for _, test := range tests {
-		_, err := NewFloatEnumValidator(test.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.Expected) {
-			t.Errorf("expected:%v, actual:%v", reflect.TypeOf(test.Expected), reflect.TypeOf(err))
-		}
-	}
-}
-
-type FloatEnumValidatorTestCase struct {
-	Input    float64
-	Expected error
-}
-
-func TestFloatEnumvalidator(t *testing.T) {
-	definition := FloatEnumValidatorDefinition{
+	definition = EnumValidatorDefinition{
 		Enumerate: []float64{0.9, 1.0, 1.1},
 	}
-	validator, err := NewFloatEnumValidator(definition)
+	validator, err = NewEnumValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tests := []FloatEnumValidatorTestCase{{
-		Input:    0.9,
-		Expected: nil,
-	}, {
-		Input:    1.0,
-		Expected: nil,
-	}, {
-		Input:    1.1,
-		Expected: nil,
-	}, {
-		Input: 1.5,
-		Expected: &FloatEnumValidationError{
-			Input:      1.5,
-			Definition: definition,
+	tests = []EnumValidatorTestCase{
+		{
+			Input:    0.9,
+			Expected: nil,
 		},
-	}}
+		{
+			Input:    1.0,
+			Expected: nil,
+		},
+		{
+			Input:    1.1,
+			Expected: nil,
+		},
+		{
+			Input: 1.5,
+			Expected: &EnumValidationError{
+				Input:      1.5,
+				Definition: definition,
+			},
+		},
+		{
+			Input: "hoge",
+			Expected: TypeError{
+				message: "input and element of enumerate should be same type",
+			},
+		},
+		{
+			Input: true,
+			Expected: TypeError{
+				message: "input should be same type as element of enumerate",
+			},
+		},
+	}
 	for _, test := range tests {
 		err := validator.Validate(test.Input)
 		if !reflect.DeepEqual(err, test.Expected) {
 			t.Errorf("expected:%v ,actual:%v", test.Expected, err)
 		}
 	}
-}
 
-type StringEnumTestCase struct {
-	Definition StringEnumValidatorDefinition
-	Expected   error
-}
-
-func TestStringEnum(t *testing.T) {
-	tests := []StringEnumTestCase{{
-		Definition: StringEnumValidatorDefinition{Enumerate: []string{}},
-		Expected:   EmptyError{},
-	}, {
-		Definition: StringEnumValidatorDefinition{Enumerate: []string{"foo", "bar", "foo"}},
-		Expected:   DuplicationError{},
-	}}
-	for _, test := range tests {
-		_, err := NewStringEnumValidator(test.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.Expected) {
-			t.Errorf("expected:%v, actual:%v", reflect.TypeOf(test.Expected), reflect.TypeOf(err))
-		}
-	}
-}
-
-type StringEnumValidatorTestCase struct {
-	Input    string
-	Expected error
-}
-
-func TestStringEnumvalidator(t *testing.T) {
-	definition := StringEnumValidatorDefinition{
+	definition = EnumValidatorDefinition{
 		Enumerate: []string{"foo", "bar", "baz"},
 	}
-	validator, err := NewStringEnumValidator(definition)
+	validator, err = NewEnumValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tests := []StringEnumValidatorTestCase{{
-		Input:    "foo",
-		Expected: nil,
-	}, {
-		Input:    "bar",
-		Expected: nil,
-	}, {
-		Input:    "baz",
-		Expected: nil,
-	}, {
-		Input: "qux",
-		Expected: &StringEnumValidationError{
-			Input:      "qux",
-			Definition: definition,
+	tests = []EnumValidatorTestCase{
+		{
+			Input:    "foo",
+			Expected: nil,
 		},
-	}}
+		{
+			Input:    "bar",
+			Expected: nil,
+		},
+		{
+			Input:    "baz",
+			Expected: nil,
+		},
+		{
+			Input: "qux",
+			Expected: &EnumValidationError{
+				Input:      "qux",
+				Definition: definition,
+			},
+		},
+		{
+			Input: 10,
+			Expected: TypeError{
+				message: "input and element of enumerate should be same type",
+			},
+		},
+		{
+			Input: true,
+			Expected: TypeError{
+				message: "input should be same type as element of enumerate",
+			},
+		},
+	}
 	for _, test := range tests {
 		err := validator.Validate(test.Input)
 		if !reflect.DeepEqual(err, test.Expected) {


### PR DESCRIPTION
Integrate `IntEnumValidator`,`FloatEnumValidator` and `StringEnumValidator` to `EnumValidator` by using type switch.
