### PR TITLE
Tests by using type assertion

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -6,45 +6,46 @@ import (
 )
 
 func TestEnum(t *testing.T) {
-	type EnumTestCase struct {
-		Definition EnumValidatorDefinition
-		Expected   error
+	_, err := NewEnumValidator(EnumValidatorDefinition{Enumerate: []int{}})
+	_, ok := err.(EmptyError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "EmptyError")
 	}
-	cases := []EnumTestCase{
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []int{}},
-			Expected:   EmptyError{},
-		},
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []int{0, 1, 0}},
-			Expected:   DuplicationError{},
-		},
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []float64{}},
-			Expected:   EmptyError{},
-		},
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []float64{0.9, 1.0, 1.0}},
-			Expected:   DuplicationError{},
-		},
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []string{}},
-			Expected:   EmptyError{},
-		},
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []string{"foo", "bar", "foo"}},
-			Expected:   DuplicationError{},
-		},
-		{
-			Definition: EnumValidatorDefinition{Enumerate: []bool{true, false}},
-			Expected:   TypeError{},
-		},
+
+	_, err = NewEnumValidator(EnumValidatorDefinition{Enumerate: []int{0, 1, 0}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
 	}
-	for _, c := range cases {
-		_, err := NewEnumValidator(c.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
-			t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
-		}
+
+	_, err = NewEnumValidator(EnumValidatorDefinition{Enumerate: []float64{}})
+	_, ok = err.(EmptyError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "EmptyError")
+	}
+
+	_, err = NewEnumValidator(EnumValidatorDefinition{Enumerate: []float64{0.9, 1.0, 1.0}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
+	}
+
+	_, err = NewEnumValidator(EnumValidatorDefinition{Enumerate: []string{}})
+	_, ok = err.(EmptyError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "EmptyError")
+	}
+
+	_, err = NewEnumValidator(EnumValidatorDefinition{Enumerate: []string{"foo", "bar", "foo"}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
+	}
+
+	_, err = NewEnumValidator(EnumValidatorDefinition{Enumerate: []bool{true, false}})
+	_, ok = err.(TypeError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "TypeError")
 	}
 }
 

--- a/format_test.go
+++ b/format_test.go
@@ -6,22 +6,10 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	type FormatTestCase struct {
-		Definition FormatValidatorDefinition
-		Expected   error
-	}
-	cases := []FormatTestCase{
-		{
-			Definition: FormatValidatorDefinition{Format: "password"},
-			Expected:   InvalidFormatError{},
-		},
-	}
-
-	for _, c := range cases {
-		_, err := NewFormatValidator(c.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
-			t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
-		}
+	_, err := NewFormatValidator(FormatValidatorDefinition{Format: "password"})
+	_, ok := err.(InvalidFormatError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "InvalidFormatError")
 	}
 }
 

--- a/max_items_test.go
+++ b/max_items_test.go
@@ -6,19 +6,10 @@ import (
 )
 
 func TestMaxItems(t *testing.T) {
-	type MaxItemsTestCase struct {
-		Definition MaxItemsValidatorDefinition
-		Expected   error
-	}
-	cases := []MaxItemsTestCase{{
-		Definition: MaxItemsValidatorDefinition{MaxItems: -1},
-		Expected:   NoLengthError{},
-	}}
-	for _, c := range cases {
-		_, err := NewMaxItemsValidator(c.Definition)
-		if err == nil {
-			t.Errorf("expected %+v, but actual %+v", c.Expected, err)
-		}
+	_, err := NewMaxItemsValidator(MaxItemsValidatorDefinition{MaxItems: -1})
+	_, ok := err.(NoLengthError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "NoLengthError")
 	}
 }
 

--- a/max_length_test.go
+++ b/max_length_test.go
@@ -6,23 +6,10 @@ import (
 )
 
 func TestMaxLength(t *testing.T) {
-	type MaxLengthTestCase struct {
-		Definition MaxLengthValidatorDefinition
-		Expected   error
-	}
-
-	cases := []MaxLengthTestCase{
-		{
-			Definition: MaxLengthValidatorDefinition{MaxLength: -1},
-			Expected:   NoLengthError{},
-		},
-	}
-
-	for _, c := range cases {
-		_, err := NewMaxLengthValidator(c.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
-			t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
-		}
+	_, err := NewMaxLengthValidator(MaxLengthValidatorDefinition{MaxLength: -1})
+	_, ok := err.(NoLengthError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "NoLengthError")
 	}
 }
 

--- a/min_items_test.go
+++ b/min_items_test.go
@@ -5,22 +5,11 @@ import (
 	"testing"
 )
 
-func TestIntMinItems(t *testing.T) {
-	type IntMinItemsTestCase struct {
-		Definition MinItemsValidatorDefinition
-		Expected   error
-	}
-	cases := []IntMinItemsTestCase{
-		{
-			Definition: MinItemsValidatorDefinition{MinItems: -1},
-			Expected:   NoLengthError{},
-		},
-	}
-	for _, c := range cases {
-		_, err := NewMinItemsValidator(c.Definition)
-		if err == nil {
-			t.Errorf("expected %v, but actual %v", c.Expected, err)
-		}
+func TestMinItems(t *testing.T) {
+	_, err := NewMinItemsValidator(MinItemsValidatorDefinition{MinItems: -1})
+	_, ok := err.(NoLengthError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "NoLengthError")
 	}
 }
 

--- a/min_length_test.go
+++ b/min_length_test.go
@@ -6,22 +6,10 @@ import (
 )
 
 func TestMinLength(t *testing.T) {
-	type MinLengthTestCase struct {
-		Definition MinLengthValidatorDefinition
-		Expected   error
-	}
-	cases := []MinLengthTestCase{
-		{
-			Definition: MinLengthValidatorDefinition{MinLength: -1},
-			Expected:   NoLengthError{},
-		},
-	}
-
-	for _, c := range cases {
-		_, err := NewMinLengthValidator(c.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
-			t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
-		}
+	_, err := NewMinLengthValidator(MinLengthValidatorDefinition{MinLength: -1})
+	_, ok := err.(NoLengthError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "NoLengthError")
 	}
 }
 

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -6,25 +6,16 @@ import (
 )
 
 func TestPattern(t *testing.T) {
-	type PatternTestCase struct {
-		Definition PatternValidatorDefinition
-		Expected   error
+	_, err := NewPatternValidator(PatternValidatorDefinition{Pattern: ""})
+	_, ok := err.(EmptyError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "EmptyError")
 	}
-	cases := []PatternTestCase{
-		{
-			Definition: PatternValidatorDefinition{Pattern: ""},
-			Expected:   EmptyError{},
-		},
-		{
-			Definition: PatternValidatorDefinition{Pattern: "[a-z"},
-			Expected:   InvalidPatternError{},
-		},
-	}
-	for _, c := range cases {
-		_, err := NewPatternValidator(c.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
-			t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
-		}
+
+	_, err = NewPatternValidator(PatternValidatorDefinition{Pattern: "[a-z"})
+	_, ok = err.(InvalidPatternError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "InvalidPatternError")
 	}
 }
 

--- a/required_test.go
+++ b/required_test.go
@@ -8,37 +8,34 @@ import (
 )
 
 func TestRequired(t *testing.T) {
-	type RequiredTestCase struct {
-		Definition RequiredValidatorDefinition
-		Expected   error
+	_, err := NewRequiredValidator(RequiredValidatorDefinition{Required: []string{}})
+	_, ok := err.(EmptyError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "EmptyError")
 	}
-	cases := []RequiredTestCase{
-		{
-			Definition: RequiredValidatorDefinition{Required: []string{}},
-			Expected:   EmptyError{},
-		},
-		{
-			Definition: RequiredValidatorDefinition{Required: []string{"foo", "foo", "bar"}},
-			Expected:   DuplicationError{},
-		},
-		{
-			Definition: RequiredValidatorDefinition{Required: []string{"foo", "bar", "foo"}},
-			Expected:   DuplicationError{},
-		},
-		{
-			Definition: RequiredValidatorDefinition{Required: []string{"bar", "foo", "foo"}},
-			Expected:   DuplicationError{},
-		},
-		{
-			Definition: RequiredValidatorDefinition{Required: []string{"foo", "foo", "foo"}},
-			Expected:   DuplicationError{},
-		},
+
+	_, err = NewRequiredValidator(RequiredValidatorDefinition{Required: []string{"foo", "foo", "bar"}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
 	}
-	for _, c := range cases {
-		_, err := NewRequiredValidator(c.Definition)
-		if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
-			t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
-		}
+
+	_, err = NewRequiredValidator(RequiredValidatorDefinition{Required: []string{"foo", "bar", "foo"}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
+	}
+
+	_, err = NewRequiredValidator(RequiredValidatorDefinition{Required: []string{"bar", "foo", "foo"}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
+	}
+
+	_, err = NewRequiredValidator(RequiredValidatorDefinition{Required: []string{"foo", "foo", "foo"}})
+	_, ok = err.(DuplicationError)
+	if !ok {
+		t.Errorf("Type of error expected %v, but not.", "DuplicationError")
 	}
 }
 


### PR DESCRIPTION
Uses type assertion instead of `reflect.TypeOf` in test.

Before:

``` go
func TestFormat(t *testing.T) {
    type FormatTestCase struct {
        Definition FormatValidatorDefinition
        Expected   error
    }
    cases := []FormatTestCase{
        {
            Definition: FormatValidatorDefinition{Format: "password"},
            Expected:   InvalidFormatError{},
        },
    }

    for _, c := range cases {
        _, err := NewFormatValidator(c.Definition)
        if reflect.TypeOf(err) != reflect.TypeOf(c.Expected) {
            t.Errorf("expected %v, but actual %v", reflect.TypeOf(c.Expected), reflect.TypeOf(err))
        }
    }
}
```

After:

``` go
func TestFormat(t *testing.T) {
    _, err := NewFormatValidator(FormatValidatorDefinition{Format: "password"})
    _, ok := err.(InvalidFormatError)
    if !ok {
        t.Errorf("Type of error expected %v, but not.", "InvalidFormatError")
    }
}
```
