### PR TITLE
Support format of password-0Aa

### DIFF
--- a/format.go
+++ b/format.go
@@ -41,31 +41,31 @@ func (f FormatValidator) Validate(input string) error {
 	switch f.definition.Format {
 	case "date-time":
 		ok := rDateTime.MatchString(input)
-		if ok == true {
+		if ok {
 			return nil
 		}
 		break
 	case "email":
 		ok := rEmail.MatchString(input)
-		if ok == true {
+		if ok {
 			return nil
 		}
 		break
 	case "hostname":
 		ok := isHostName(input)
-		if ok == true {
+		if ok {
 			return nil
 		}
 		break
 	case "uri":
 		ok := rURI.MatchString(input)
-		if ok == true {
+		if ok {
 			return nil
 		}
 		break
-	case "password-0aA":
+	case "password-0Aa":
 		ok := isPassword0Aa(input)
-		if ok == true {
+		if ok {
 			return nil
 		}
 		break

--- a/format.go
+++ b/format.go
@@ -31,7 +31,7 @@ func (f FormatValidationError) Error() string {
 
 func NewFormatValidator(definition FormatValidatorDefinition) (FormatValidator, error) {
 	switch definition.Format {
-	case "date-time", "email", "hostname", "uri":
+	case "date-time", "email", "hostname", "uri", "password-0Aa":
 		return FormatValidator{definition}, nil
 	}
 	return FormatValidator{}, InvalidFormatError{"the format is not found"}
@@ -59,6 +59,12 @@ func (f FormatValidator) Validate(input string) error {
 		break
 	case "uri":
 		ok := rURI.MatchString(input)
+		if ok == true {
+			return nil
+		}
+		break
+	case "password-0aA":
+		ok := isPassword0Aa(input)
 		if ok == true {
 			return nil
 		}
@@ -113,4 +119,29 @@ func isHostName(s string) bool {
 	}
 
 	return ok
+}
+
+func isPassword0Aa(pw string) bool {
+	large := false
+	small := false
+	number := false
+
+	for _, r := range pw {
+		switch {
+		case '0' <= r && r <= '9':
+			number = true
+			continue
+		case 'A' <= r && r <= 'Z':
+			large = true
+			continue
+		case 'a' <= r && r <= 'z':
+			small = true
+			continue
+		case '!' <= r && r <= '~': // when other ASCII characters
+			continue
+		default:
+			return false
+		}
+	}
+	return large && small && number
 }

--- a/format_test.go
+++ b/format_test.go
@@ -193,7 +193,7 @@ func TestFormatValidator(t *testing.T) {
 	}
 
 	definition = FormatValidatorDefinition{
-		Format: "password-0aA",
+		Format: "password-0Aa",
 	}
 	validator, err = NewFormatValidator(definition)
 	if err != nil {
@@ -202,11 +202,127 @@ func TestFormatValidator(t *testing.T) {
 
 	cases = []FormatValidationTestCase{
 		{
+			Input:    "0Aa",
+			Expected: nil,
+		},
+		{
+			Input:    "0aA",
+			Expected: nil,
+		},
+		{
+			Input:    "A0a",
+			Expected: nil,
+		},
+		{
+			Input:    "Aa0",
+			Expected: nil,
+		},
+		{
+			Input:    "a0A",
+			Expected: nil,
+		},
+		{
 			Input:    "aA0",
 			Expected: nil,
 		},
 		{
+			Input:    "!0Aa",
+			Expected: nil,
+		},
+		{
+			Input:    "!0aA",
+			Expected: nil,
+		},
+		{
+			Input:    "!A0a",
+			Expected: nil,
+		},
+		{
+			Input:    "!Aa0",
+			Expected: nil,
+		},
+		{
+			Input:    "!a0A",
+			Expected: nil,
+		},
+		{
+			Input:    "!aA0",
+			Expected: nil,
+		},
+		{
+			Input:    "0!Aa",
+			Expected: nil,
+		},
+		{
+			Input:    "0!aA",
+			Expected: nil,
+		},
+		{
+			Input:    "0A!a",
+			Expected: nil,
+		},
+		{
+			Input:    "0Aa!",
+			Expected: nil,
+		},
+		{
+			Input:    "0a!A",
+			Expected: nil,
+		},
+		{
+			Input:    "0aA!",
+			Expected: nil,
+		},
+		{
+			Input:    "A!0a",
+			Expected: nil,
+		},
+		{
+			Input:    "A!a0",
+			Expected: nil,
+		},
+		{
+			Input:    "A0!a",
+			Expected: nil,
+		},
+		{
+			Input:    "A0a!",
+			Expected: nil,
+		},
+		{
+			Input:    "Aa!0",
+			Expected: nil,
+		},
+		{
+			Input:    "Aa0!",
+			Expected: nil,
+		},
+		{
+			Input:    "a!0A",
+			Expected: nil,
+		},
+		{
+			Input:    "a!A0",
+			Expected: nil,
+		},
+		{
+			Input:    "a0!A",
+			Expected: nil,
+		},
+		{
+			Input:    "a0A!",
+			Expected: nil,
+		},
+		{
+			Input:    "aA!0",
+			Expected: nil,
+		},
+		{
 			Input:    "aA0!",
+			Expected: nil,
+		},
+		{
+			Input:    "AZaz09!\"#$%&'()*+,-./:;<=>?@[\\]^_{|}~`",
 			Expected: nil,
 		},
 		{

--- a/format_test.go
+++ b/format_test.go
@@ -191,4 +191,79 @@ func TestFormatValidator(t *testing.T) {
 			t.Errorf("expected %v, but actual %v", c.Expected, err)
 		}
 	}
+
+	definition = FormatValidatorDefinition{
+		Format: "password-0aA",
+	}
+	validator, err = NewFormatValidator(definition)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	cases = []FormatValidationTestCase{
+		{
+			Input:    "aA0",
+			Expected: nil,
+		},
+		{
+			Input:    "aA0!",
+			Expected: nil,
+		},
+		{
+			Input: "aA0!あ",
+			Expected: &FormatValidationError{
+				Input:      "aA0!あ",
+				Definition: definition,
+			},
+		},
+		{
+			Input: "12345678",
+			Expected: &FormatValidationError{
+				Input:      "12345678",
+				Definition: definition,
+			},
+		},
+		{
+			Input: "password",
+			Expected: &FormatValidationError{
+				Input:      "password",
+				Definition: definition,
+			},
+		},
+		{
+			Input: "PASSWORD",
+			Expected: &FormatValidationError{
+				Input:      "PASSWORD",
+				Definition: definition,
+			},
+		},
+		{
+			Input: "Password",
+			Expected: &FormatValidationError{
+				Input:      "Password",
+				Definition: definition,
+			},
+		},
+		{
+			Input: "password123",
+			Expected: &FormatValidationError{
+				Input:      "password123",
+				Definition: definition,
+			},
+		},
+		{
+			Input: "PASSWORD123",
+			Expected: &FormatValidationError{
+				Input:      "PASSWORD123",
+				Definition: definition,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		err := validator.Validate(c.Input)
+		if !reflect.DeepEqual(err, c.Expected) {
+			t.Errorf("expected %v, but actual %v", c.Expected, err)
+		}
+	}
 }

--- a/format_test.go
+++ b/format_test.go
@@ -1,23 +1,25 @@
-package validator
+package validator_test
 
 import (
 	"reflect"
 	"testing"
+
+	validator "github.com/go-jstmpl/go-jsvalidator"
 )
 
 func TestFormat(t *testing.T) {
-	_, err := NewFormatValidator(FormatValidatorDefinition{Format: "password"})
-	_, ok := err.(InvalidFormatError)
+	_, err := validator.NewFormatValidator(validator.FormatValidatorDefinition{Format: "password"})
+	_, ok := err.(validator.InvalidFormatError)
 	if !ok {
 		t.Errorf("Type of error expected %v, but not.", "InvalidFormatError")
 	}
 }
 
 func TestFormatValidator(t *testing.T) {
-	definition := FormatValidatorDefinition{
+	definition := validator.FormatValidatorDefinition{
 		Format: "date-time",
 	}
-	validator, err := NewFormatValidator(definition)
+	va, err := validator.NewFormatValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -33,7 +35,7 @@ func TestFormatValidator(t *testing.T) {
 		},
 		{
 			Input: "209385790284750",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "209385790284750",
 				Definition: definition,
 			},
@@ -41,15 +43,15 @@ func TestFormatValidator(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := validator.Validate(c.Input)
+		err := va.Validate(c.Input)
 		if !reflect.DeepEqual(err, c.Expected) {
 			t.Errorf("expected:%v ,actual:%v", c.Expected, err)
 		}
 	}
-	definition = FormatValidatorDefinition{
+	definition = validator.FormatValidatorDefinition{
 		Format: "email",
 	}
-	validator, err = NewFormatValidator(definition)
+	va, err = validator.NewFormatValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -61,21 +63,21 @@ func TestFormatValidator(t *testing.T) {
 		},
 		{
 			Input: "foobar.com",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "foobar.com",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "foo@bar",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "foo@bar",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "foo@bar.",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "foo@bar.",
 				Definition: definition,
 			},
@@ -83,16 +85,16 @@ func TestFormatValidator(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := validator.Validate(c.Input)
+		err := va.Validate(c.Input)
 		if !reflect.DeepEqual(err, c.Expected) {
 			t.Errorf("expected %v, but actual %v", c.Expected, err)
 		}
 	}
 
-	definition = FormatValidatorDefinition{
+	definition = validator.FormatValidatorDefinition{
 		Format: "hostname",
 	}
-	validator, err = NewFormatValidator(definition)
+	va, err = validator.NewFormatValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -116,28 +118,28 @@ func TestFormatValidator(t *testing.T) {
 		},
 		{
 			Input: "example@example.com",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "example@example.com",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "example,com",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "example,com",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "example..com",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "example..com",
 				Definition: definition,
 			},
 		},
 		{
 			Input: ".example.com",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      ".example.com",
 				Definition: definition,
 			},
@@ -145,16 +147,16 @@ func TestFormatValidator(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := validator.Validate(c.Input)
+		err := va.Validate(c.Input)
 		if !reflect.DeepEqual(err, c.Expected) {
 			t.Errorf("expected %v, but actual %v", c.Expected, err)
 		}
 	}
 
-	definition = FormatValidatorDefinition{
+	definition = validator.FormatValidatorDefinition{
 		Format: "uri",
 	}
-	validator, err = NewFormatValidator(definition)
+	va, err = validator.NewFormatValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -178,7 +180,7 @@ func TestFormatValidator(t *testing.T) {
 		},
 		{
 			Input: "foobar.com",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "foobar.com",
 				Definition: definition,
 			},
@@ -186,16 +188,16 @@ func TestFormatValidator(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := validator.Validate(c.Input)
+		err := va.Validate(c.Input)
 		if !reflect.DeepEqual(err, c.Expected) {
 			t.Errorf("expected %v, but actual %v", c.Expected, err)
 		}
 	}
 
-	definition = FormatValidatorDefinition{
+	definition = validator.FormatValidatorDefinition{
 		Format: "password-0Aa",
 	}
-	validator, err = NewFormatValidator(definition)
+	va, err = validator.NewFormatValidator(definition)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -327,49 +329,49 @@ func TestFormatValidator(t *testing.T) {
 		},
 		{
 			Input: "aA0!あ",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "aA0!あ",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "12345678",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "12345678",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "password",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "password",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "PASSWORD",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "PASSWORD",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "Password",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "Password",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "password123",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "password123",
 				Definition: definition,
 			},
 		},
 		{
 			Input: "PASSWORD123",
-			Expected: &FormatValidationError{
+			Expected: &validator.FormatValidationError{
 				Input:      "PASSWORD123",
 				Definition: definition,
 			},
@@ -377,7 +379,7 @@ func TestFormatValidator(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := validator.Validate(c.Input)
+		err := va.Validate(c.Input)
 		if !reflect.DeepEqual(err, c.Expected) {
 			t.Errorf("expected %v, but actual %v", c.Expected, err)
 		}

--- a/format_test.go
+++ b/format_test.go
@@ -324,7 +324,7 @@ func TestFormatValidator(t *testing.T) {
 			Expected: nil,
 		},
 		{
-			Input:    "AZaz09!\"#$%&'()*+,-./:;<=>?@[\\]^_{|}~`",
+			Input:    "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
 			Expected: nil,
 		},
 		{


### PR DESCRIPTION
Supported format of `password-0Aa`
## What is the `password-0Aa` format

**MUST** use at least one characters in:
- `0-9`
- `A-Z`
- `a-z`

**CAN** use:

ASCII characters except for white space.
